### PR TITLE
Initialize projects from superhuman-plus template

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Bolt.new: AI-Powered Full-Stack Web Development in the Browser
 
-Bolt.new is an AI-powered web development agent that allows you to prompt, run, edit, and deploy full-stack applications directly from your browser—no local setup required. If you're here to build your own AI-powered web dev agent using the Bolt open source codebase, [click here to get started!](./CONTRIBUTING.md)
+Bolt.new is an AI-powered web development agent that allows you to prompt, run, edit, and deploy full-stack applications directly from your browser—no local setup required. By default, new projects start from the [superhuman-plus](https://github.com/thegarrettscott/superhuman-plus) template. If you're here to build your own AI-powered web dev agent using the Bolt open source codebase, [click here to get started!](./CONTRIBUTING.md)
 
 ## What Makes Bolt.new Different
 

--- a/app/components/sidebar/Menu.client.tsx
+++ b/app/components/sidebar/Menu.client.tsx
@@ -2,7 +2,6 @@ import { motion, type Variants } from 'framer-motion';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'react-toastify';
 import { Dialog, DialogButton, DialogDescription, DialogRoot, DialogTitle } from '~/components/ui/Dialog';
-import { IconButton } from '~/components/ui/IconButton';
 import { ThemeSwitch } from '~/components/ui/ThemeSwitch';
 import { db, deleteById, getAll, chatId, type ChatHistoryItem } from '~/lib/persistence';
 import { cubicEasingFn } from '~/utils/easings';

--- a/app/lib/webcontainer/index.ts
+++ b/app/lib/webcontainer/index.ts
@@ -24,8 +24,19 @@ if (!import.meta.env.SSR) {
       .then(() => {
         return WebContainer.boot({ workdirName: WORK_DIR_NAME });
       })
-      .then((webcontainer) => {
+      .then(async (webcontainer) => {
         webcontainerContext.loaded = true;
+
+        try {
+          const process = await webcontainer.spawn('jsh', [
+            '-c',
+            'test -f package.json || npx --yes degit thegarrettscott/superhuman-plus .',
+          ]);
+          await process.exit;
+        } catch (error) {
+          console.error('Failed to initialize project', error);
+        }
+
         return webcontainer;
       });
 


### PR DESCRIPTION
## Summary
- Clone the `thegarrettscott/superhuman-plus` repository into the WebContainer on startup so new chats begin with that template
- Document that all projects start from the superhuman-plus template
- Remove an unused import in the sidebar menu to keep linting clean

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad10854a7883319ba8cc683a5d6660